### PR TITLE
Added `forceCaseStyle` option to control the forcing one of the camel…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 ### 0.1.0
 
 Features: Transforming underscored and dashed selectors to camel-case ones.
+
+### 0.1.1
+
+Features: Added `option` to support forcing the transformation to one of two kinds of camelCase styles, including an option to turn this forcing off. This option is:
+- forceCamelStyle: (`lowerCamelCase` | `UpperCamelCase` | `off`)
+  - NOTE: the default when no option is provide is `lowerCamelCase` to support backwards compatibility with version `0.1.0`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Camelcaser transforms all your selectors to camel case, by default choosing to f
 ```
 ## options
 ### `forceCaseStyle`
-type: `('lowerCamelCase' | 'upperCamelCase' | 'off')`
+type: `('lowerCamelCase' | 'UpperCamelCase' | 'off')`
 
 default: `lowerCamelCase`
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PostCSS Camelcaser [![Build Status][ci-img]][ci]
 
-[PostCSS] plugin which camelcases all your selectors..
+[PostCSS] plugin which camelcases all your selectors.
 
 [PostCSS]: https://github.com/postcss/postcss
 [ci-img]:  https://travis-ci.org/GMchris/postcss-camelcaser.svg
 [ci]:      https://travis-ci.org/GMchris/postcss-camelcaser
 
-Camelcaser transforms all your selectors to camel case, 
+Camelcaser transforms all your selectors to camel case, by default choosing to force the output to `lowerCamelCase`.
 
 ```css
 .camel-case-me {
@@ -19,11 +19,28 @@ Camelcaser transforms all your selectors to camel case,
   /* Same stuff */
 }
 ```
+## options
+### `forceCaseStyle`
+type: `('lowerCamelCase' | 'upperCamelCase' | 'off')`
+
+default: `lowerCamelCase`
+
+Will force the camel case transformation to a specific (camel case)[https://en.wikipedia.org/wiki/Camel_case] style.
+
+The default style option, `lowerCamelCase`, will ensure that all transformation will have the lower camel case style:
+- `Camel-case_me` => `camelCaseMe`
+
+The `UpperCamelCase` style option will ensure that all transformations will have the upper camel case style:
+- `camel-case_me` => `CamelCaseMe`
+
+Using the `off` style option will maintain the case of the leading letter:
+- `Camel-case_me` => `CamelCaseMe`
+- `camel-case_me` => `camelCaseMe`
 
 ## Usage
 
 ```js
-postcss([ require('postcss-camelcaser') ])
+postcss([ require('postcss-camelcaser')(/* options */{}), ])
 ```
 
 See [PostCSS] docs for examples for your environment.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ type: `('lowerCamelCase' | 'upperCamelCase' | 'off')`
 
 default: `lowerCamelCase`
 
-Will force the camel case transformation to a specific (camel case)[https://en.wikipedia.org/wiki/Camel_case] style.
+Will force the camel case transformation to a specific [camel case](https://en.wikipedia.org/wiki/Camel_case) style.
 
 The default style option, `lowerCamelCase`, will ensure that all transformation will have the lower camel case style:
 - `Camel-case_me` => `camelCaseMe`

--- a/index.js
+++ b/index.js
@@ -4,14 +4,12 @@ module.exports = postcss.plugin('camelcaser', function camelcaser(options) {
     return function (css) {
         options = options || {};
         var forceCaseStyle = options.forceCaseStyle || 'lowerCamelCase';
-        console.log('forceCaseStyle', forceCaseStyle, options);
 
         css.walkRules(function (rule) {
             var output = rule.selector.replace(/(-|_){1,}\w/g,
             function (match) {
                 return match[match.length - 1].toUpperCase();
             });
-            console.log('output 1', output);
             switch (forceCaseStyle) {
             case 'off':
                 break;
@@ -27,7 +25,6 @@ module.exports = postcss.plugin('camelcaser', function camelcaser(options) {
                 });
                 break;
             }
-            console.log('output 2', output);
             rule.selector = output;
         });
     };

--- a/index.js
+++ b/index.js
@@ -3,14 +3,32 @@ var postcss = require('postcss');
 module.exports = postcss.plugin('camelcaser', function camelcaser(options) {
     return function (css) {
         options = options || {};
+        var forceCaseStyle = options.forceCaseStyle || 'lowerCamelCase';
+        console.log('forceCaseStyle', forceCaseStyle, options);
 
         css.walkRules(function (rule) {
-            rule.selector = rule.selector.replace(/(-|_){1,}\w/g,
+            var output = rule.selector.replace(/(-|_){1,}\w/g,
             function (match) {
                 return match[match.length - 1].toUpperCase();
-            }).replace(/(\W)[A-Z]/g, function (match) {
-                return match.toLowerCase();
             });
+            console.log('output 1', output);
+            switch (forceCaseStyle) {
+            case 'off':
+                break;
+            case 'UpperCamelCase':
+                output = output.replace(/(\W)[a-z]/g, function (match) {
+                    return match.toUpperCase();
+                });
+                break;
+            case 'lowerCamelCase':
+            default:
+                output = output.replace(/(\W)[A-Z]/g, function (match) {
+                    return match.toLowerCase();
+                });
+                break;
+            }
+            console.log('output 2', output);
+            rule.selector = output;
         });
     };
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-camelcaser",
-  "version": "0.0.0",
+  "version": "0.1.1",
   "description": "PostCSS plugin which camelcases all your selectors.",
   "keywords": [
     "postcss",

--- a/test.js
+++ b/test.js
@@ -3,6 +3,16 @@ import test    from 'ava';
 
 import plugin from './';
 
+const UPPER_INPUT = '.Camel-case_this{}';
+const LOWER_INPUT = '.camel-case_this{}';
+
+const UPPER_OUTPUT = '.CamelCaseThis{}';
+const LOWER_OUTPUT = '.camelCaseThis{}';
+
+const FORCE_LOWER = { forceCaseStyle: 'lowerCamelCase' };
+const FORCE_UPPER = { forceCaseStyle: 'UpperCamelCase' };
+const FORCE_OFF = { forceCaseStyle: 'off' };
+
 function run(t, input, output, opts = { }) {
     return postcss([ plugin(opts) ]).process(input)
         .then( result => {
@@ -11,6 +21,34 @@ function run(t, input, output, opts = { }) {
         });
 }
 
-test('Transforms to camelcase', t=> {
-    return run(t, '.Camel-case_this{}', '.camelCaseThis{}', {});
+test('Transforms UpperInput to camelcase, default options', t=> {
+    return run(t, UPPER_INPUT, LOWER_OUTPUT, {});
+});
+
+test('Transforms lowerInput to camelcase, default options', t=> {
+    return run(t, LOWER_INPUT, LOWER_OUTPUT, {});
+});
+
+test('Transforms UpperInput to camelcase, forced lower', t=> {
+    return run(t, UPPER_INPUT, LOWER_OUTPUT, FORCE_LOWER);
+});
+
+test('Transforms lowerInput to camelcase, forced lower', t=> {
+    return run(t, LOWER_INPUT, LOWER_OUTPUT, FORCE_LOWER);
+});
+
+test('Transforms UpperInput to camelcase, forced Upper', t=> {
+    return run(t, UPPER_INPUT, UPPER_OUTPUT, FORCE_UPPER);
+});
+
+test('Transforms lowerInput to camelcase, forced Upper', t=> {
+    return run(t, LOWER_INPUT, UPPER_OUTPUT, FORCE_UPPER);
+});
+
+test('Transforms UpperInput to camelcase, forced off', t=> {
+    return run(t, UPPER_INPUT, UPPER_OUTPUT, FORCE_OFF);
+});
+
+test('Transforms lowerInput to camelcase, forced Upper', t=> {
+    return run(t, LOWER_INPUT, LOWER_OUTPUT, FORCE_OFF);
 });


### PR DESCRIPTION
…Case transformation styles

- According to the `Camel Case Wikipedia` page there are two alternative forms of camel case styles
  - lower camel case (i.e. lowerCamelCase) and
  - upper camel case (i.e. UpperCamelCase)
- The new option controls whether to force the output to one of these two styles or turning off the force